### PR TITLE
Use shields.io instead of badge.fury.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # event_stream_parser
 
-[![Gem Version](https://badge.fury.io/rb/event_stream_parser.svg)](https://badge.fury.io/rb/event_stream_parser)
+[![Gem (including prereleases)](https://img.shields.io/gem/v/event_stream_parser)](https://rubygems.org/gems/event_stream_parser)
 [![CI](https://github.com/Shopify/event_stream_parser/actions/workflows/ci.yml/badge.svg)](https://github.com/Shopify/event_stream_parser/actions/workflows/ci.yml)
 
 A lightweight, fully spec-compliant parser for the


### PR DESCRIPTION
GH caches the badge image, despite cache headers in the response. Let's try an alternative provider that doesn't serve the image through a redirect.