### PR TITLE
1.0.0 🎉 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 1.0.0
+
+- Fix example in README and deem public contract stable
+
 # 0.3.0
 
 - Add support for Ruby 2.6, drop rubocop-shopify

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ gem install event_stream_parser
 
 ## Usage
 
-Create a new Parser and give it a block to receive events:
+Create a new Parser:
 
 ```rb
 parser = EventStreamParser::Parser.new
-
-parser.feed do |type, data, id, reconnection_time|
-  puts "Event type: #{type}"
-  puts "Event data: #{data}"
-  puts "Event id: #{id}"
-  puts "Reconnection time: #{reconnection_time}"
-end
 ```
 
 Then, feed it chunks as they come in:
 
 ```rb
-do_something_that_yields_chunks do { |chunk| parser.feed(chunk) }
+do_something_that_yields_chunks do |chunk|
+  parser.feed(chunk) do |type, data, id, reconnection_time|
+    puts "Event type: #{type}"
+    puts "Event data: #{data}"
+    puts "Event id: #{id}"
+    puts "Reconnection time: #{reconnection_time}"
+  end
+end
 ```
 
 Or use the `stream` method to generate a proc that you can pass to a chunk

--- a/lib/event_stream_parser/version.rb
+++ b/lib/event_stream_parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EventStreamParser
-  VERSION = '0.3.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
No issues have been reported since the incorporation into ruby-openai (millions of downloads).

Deeming the public interface stable and bumping the version to 1.0.0.